### PR TITLE
Mentioned required parameters when executing `passwordlessVerify` met…

### DIFF
--- a/articles/libraries/auth0js/index.md
+++ b/articles/libraries/auth0js/index.md
@@ -208,6 +208,7 @@ In addition, _one_ of the two following options must be sent:
 * `phoneNumber`: a string containing the user's phone number, to which the code or link was delivered via SMS
 * `email`: a string containing the user's email, to which the code or link was delivered via email
 
+Additionally the values `redirectUri` and `responseType: 'token'` must be specified as options when initialising `WebAuth`.
 
 ```js
 webAuth.passwordlessVerify({


### PR DESCRIPTION
…hod.

Mentioned that the properties `redirectUri` and `responseType` must be set when initialising `WebAuth` when calling the password less verify method `passwordlessVerify`.

If one of the properties is missing you either get the message `invalid_request: Missing required parameter: response_type` or `server_error: Unable to issue redirect for OAuth 2.0 transaction` which is not clear for the consumer of the library.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
